### PR TITLE
add blank main.nf as tower placeholder

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,0 +1,3 @@
+// This main.nf file as a temporary placeholder to meet the Nextflow tower launchpad requirement.
+// Note: Nextflow tower launchpad cannot be saved if main.nf is not available in the main/master branch. 
+// This file can be removed once this issue has been resolved.

--- a/main.nf
+++ b/main.nf
@@ -1,3 +1,3 @@
-// This main.nf file as a temporary placeholder to meet the Nextflow tower launchpad requirement.
+// This main.nf file is a temporary placeholder added for the Nextflow tower launchpad requirement.
 // Note: Nextflow tower launchpad cannot be saved if main.nf is not available in the main/master branch. 
 // This file can be removed once this issue has been resolved.

--- a/main.nf
+++ b/main.nf
@@ -1,3 +1,3 @@
-// This main.nf file is a temporary placeholder added for the Nextflow tower launchpad requirement.
+// This main.nf file is a temporary placeholder added to meet the Nextflow tower launchpad requirement.
 // Note: Nextflow tower launchpad cannot be saved if main.nf is not available in the main/master branch. 
 // This file can be removed once this issue has been resolved.


### PR DESCRIPTION
Add main.nf file as a temporary placeholder to meet the Nextflow tower launchpad requirement. 
Note: Nextflow tower launchpad cannot be saved if main.nf is not available in the main/master branch. This file can be removed once this issue has been resolved.