### PR TITLE
remove workspace id

### DIFF
--- a/nextflow-lib/nextflow.config
+++ b/nextflow-lib/nextflow.config
@@ -28,10 +28,10 @@ profiles {
 //            perJobMemLimit =
 //            queue = ''
         }
-        tower {
-            workspaceId = '199373255459700' // TOWER Workspace ID for POC
+//        tower {
+//            workspaceId = 'xxxxx' // TOWER Workspace ID for POC
 //            endpoint = 'https://tower.nf'
-        }
+//        }
     }
     gls {
         params {
@@ -63,9 +63,9 @@ profiles {
             project = 'prj-int-dev-covid19-nf-gls'
 //            enableRequesterPaysBuckets = 'false'
         }
-        tower {
-            workspaceId = '199373255459700' // TOWER Workspace ID for POC 
-        }
+//        tower {
+//            workspaceId = 'xxxxx' // TOWER Workspace ID for POC 
+//        }
 //        timeline {
 //            enabled = 'true'
 //            file = 'timeline.html'


### PR DESCRIPTION
Commented workspaceID of Tower PoC. All runs should appear in the personal space instead of the common space.