### PR TITLE
Change umbrella project and sub-projects

### DIFF
--- a/nextflow-lib/ena-analysis-submitter.nf
+++ b/nextflow-lib/ena-analysis-submitter.nf
@@ -35,10 +35,11 @@ process ena_analysis_submit {
     mkdir -p ${run_accession}_output/${study_accession}
     cp ${config_yaml} ${run_accession}_output/${study_accession}
 
+    //Public study ID
     if [ "${study_accession}" = 'PRJEB45555' ]; then
-        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB57995 -s ${sample_accession} -r ${run_accession} -f ${output_bam},${output_coverage_gz},${output_annot_vcf_gz} -a PATHOGEN_ANALYSIS -au \${webin_id} -ap \${webin_password}
-        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB57993 -s ${sample_accession} -r ${run_accession} -f ${filtered_vcf_gz} -a COVID19_FILTERED_VCF -au \${webin_id} -ap \${webin_password}
-        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB57992 -s ${sample_accession} -r ${run_accession} -f ${consensus_fasta_gz} -a COVID19_CONSENSUS -au \${webin_id} -ap \${webin_password}
+        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB59443 -s ${sample_accession} -r ${run_accession} -f ${output_bam},${output_coverage_gz},${output_annot_vcf_gz} -a PATHOGEN_ANALYSIS -au \${webin_id} -ap \${webin_password}
+        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB59444 -s ${sample_accession} -r ${run_accession} -f ${filtered_vcf_gz} -a COVID19_FILTERED_VCF -au \${webin_id} -ap \${webin_password}
+        analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p PRJEB59445 -s ${sample_accession} -r ${run_accession} -f ${consensus_fasta_gz} -a COVID19_CONSENSUS -au \${webin_id} -ap \${webin_password}
     else
         analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p ${study_accession} -s ${sample_accession} -r ${run_accession} -f ${output_bam},${output_coverage_gz},${output_annot_vcf_gz} -a PATHOGEN_ANALYSIS -au \${webin_id} -ap \${webin_password}
         analysis_submission.py -t ${test_submission} -o ${run_accession}_output/${study_accession} -p ${study_accession} -s ${sample_accession} -r ${run_accession} -f ${filtered_vcf_gz} -a COVID19_FILTERED_VCF -au \${webin_id} -ap \${webin_password}


### PR DESCRIPTION
As per new structure as described here:
The new projects for SARS-CoV-2 analyses are detailed here:
PRJEB59442 This umbrella holds all analysis outputs After March 2023
•	PRJEB59443 Unfiltered Variant Calls After March 2023 (VEO COVID-19 Taskforce)
o	PATHOGEN_ANALYSIS
•	PRJEB59444 Filtered Variant Calls After March 2023 (VEO SARS-CoV-2 Taskforce)
o	COVID19_FILTERED_VCF
•	PRJEB59445 Consensus Sequences After March 2023 (VEO SARS-CoV-2 Taskforce)
o	COVID19_CONSENSUS
They are for analyses after March 2023 following the discussion in the Pathogen monthly meeting.
